### PR TITLE
Pin compatible libitk into install package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6fb294e1c7edb238aa05b23b8bd9a9ca1e3e8bf5554f7839c70abb58e1f867df
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - libboost-headers
     - libitk-devel
   run:
-    - libitk
+    - {{ pin_compatible('libitk', min_pin='x.x', max_pin='x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The ANTs package is compiled against the latest version of libitk at the time of build. The previous release happened with libitk 5.3, and started breaking when libitk 5.4 was pushed to conda-forge. So we've pinned to `libitk=5.3`. With the latest release, ANTs is compiled against libitk 5.4, so the pins to 5.3 are now causing breakage.

I was trying to get conda-forge to build a 5.3 and 5.4-compatible version of the latest release, but ANTs broke 5.3-compatibility in 2.5.2, so nevermind that.

<details><summary>If we span 5.4 and 6.0, we could revisit that.</summary>

It involved setting a variable in `recipe/conda_build_config.yaml`:

```
libitk:
  - 5.3
  - 5.4
pin_run_as_build:
  libitk:
    min_pin: x.x
    max_pin: x.x
```

and updating the build string and requirements in `recipe/meta.yaml` to distinguish the two builds:

```
build:  
  number: 1
  string: "h{{ PKG_HASH }}_itk{{ libitk|replace('.', '') }}"
...
requirements:
  build:
    - {{ compiler('cxx') }}    
    - {{ stdlib("c") }}
    - cmake >=3.16.3
    - ninja
  host:
    - libboost-headers
    - libitk-devel ={{ libitk }}=*
```

</details>

~~I believe I have tracked down the necessary bits to resolve this: https://docs.conda.io/projects/conda-build/en/stable/resources/variants.html~~

~~1) First pinning the runtime libitk requirement based on the build-time version.~~
~~2) Creating build variants that use different versions of libitk.~~

~~Not 100% sure I'm right...~~

Fixes #9.